### PR TITLE
Refactor the font styles

### DIFF
--- a/Project/Sources/Methods/SVG_Get_string_width.4dm
+++ b/Project/Sources/Methods/SVG_Get_string_width.4dm
@@ -1,39 +1,39 @@
 //%attributes = {"invisible":true,"preemptive":"capable"}
-  // ----------------------------------------------------
-  // Method : SVG_Get_string_width
-  // Created 22/07/08 by Vincent de Lachaux
-  // ----------------------------------------------------
-  // Description
-  //Returns the width of the parameter text, based on the font information.
-  // ----------------------------------------------------
-  //SVG_Get_string_width (text; font; size; style) -> width
-  //
-  //Parameter               Type                          Description
-  //text                         Text              ->        A text value
-  //font                          Alpha           ->        The font that will be used to display the text.
-  //size                          Integer         ->        The size of the font.
-  //style                         Integer         ->        The font style.
-  //result                        Real         ->        The width of the text value
-  //
-  //4D constants may be used for the style parameter. See the 4D documentation for details.
-  // ----------------------------------------------------
+// ----------------------------------------------------
+// Method : SVG_Get_string_width
+// Created 22/07/08 by Vincent de Lachaux
+// ----------------------------------------------------
+// Description
+//Returns the width of the parameter text, based on the font information.
+// ----------------------------------------------------
+//SVG_Get_string_width (text; font; size; style) -> width
+//
+//Parameter               Type                          Description
+//text                         Text              ->        A text value
+//font                          Alpha           ->        The font that will be used to display the text.
+//size                          Integer         ->        The size of the font.
+//style                         Integer         ->        The font style.
+//result                        Real         ->        The width of the text value
+//
+//4D constants may be used for the style parameter. See the 4D documentation for details.
+// ----------------------------------------------------
 C_REAL:C285($0)
 C_TEXT:C284($1)
 C_TEXT:C284($2)
 C_LONGINT:C283($3)
 C_LONGINT:C283($4)
 
-C_LONGINT:C283($Lon_fonStyle;$Lon_fontSize;$Lon_height;$Lon_Unused)
+C_LONGINT:C283($Lon_fontStyles; $Lon_fontSize; $Lon_height; $Lon_Unused)
 C_PICTURE:C286($Pic_buffer)
 C_REAL:C285($Num_width)
-C_TEXT:C284($Txt_fontName;$Txt_rootReference;$Txt_string;$Txt_textID)
+C_TEXT:C284($Txt_fontName; $Txt_rootReference; $Txt_string; $Txt_textID)
 
 If (False:C215)
-	C_REAL:C285(SVG_Get_string_width ;$0)
-	C_TEXT:C284(SVG_Get_string_width ;$1)
-	C_TEXT:C284(SVG_Get_string_width ;$2)
-	C_LONGINT:C283(SVG_Get_string_width ;$3)
-	C_LONGINT:C283(SVG_Get_string_width ;$4)
+	C_REAL:C285(SVG_Get_string_width; $0)
+	C_TEXT:C284(SVG_Get_string_width; $1)
+	C_TEXT:C284(SVG_Get_string_width; $2)
+	C_LONGINT:C283(SVG_Get_string_width; $3)
+	C_LONGINT:C283(SVG_Get_string_width; $4)
 End if 
 
 $Txt_string:=$1
@@ -42,61 +42,54 @@ $Lon_fontSize:=$3
 
 If (Count parameters:C259>=4)
 	
-	$Lon_fonStyle:=$4
+	$Lon_fontStyles:=$4
 	
 End if 
 
-$Txt_rootReference:=DOM Create XML Ref:C861("svg";"http://www.w3.org/2000/svg")
+$Txt_rootReference:=DOM Create XML Ref:C861("svg"; "http://www.w3.org/2000/svg")
 
 If (OK=1)
 	
-	$Txt_textID:=DOM Create XML element:C865($Txt_rootReference;"text")
-	DOM SET XML ATTRIBUTE:C866($Txt_textID;\
-		"font-family";$Txt_fontName)
-	DOM SET XML ATTRIBUTE:C866($Txt_textID;\
-		"font-size";$Lon_fontSize)
+	$Txt_textID:=DOM Create XML element:C865($Txt_rootReference; "text")
+	DOM SET XML ATTRIBUTE:C866($Txt_textID; \
+		"font-family"; $Txt_fontName)
+	DOM SET XML ATTRIBUTE:C866($Txt_textID; \
+		"font-size"; $Lon_fontSize)
 	
-	If ($Lon_fonStyle>=8)  //line-through
-		
-		DOM SET XML ATTRIBUTE:C866($Txt_textID;\
-			"text-decoration";"line-through")
-		$Lon_fonStyle:=$Lon_fonStyle-8
-		
+	Case of 
+		: ($Lon_fontStyles ?? 2) & ($Lon_fontStyles ?? 3)
+			DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+				"text-decoration"; "underline line-through")
+			
+		: ($Lon_fontStyles ?? 2)
+			DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+				"text-decoration"; "underline")
+			
+		: ($Lon_fontStyles ?? 3)
+			DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+				"text-decoration"; "line-through")
+	End case 
+	
+	If ($Lon_fontStyles ?? 1)
+		DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+			"font-style"; "italic")
 	End if 
 	
-	If ($Lon_fonStyle>=4)  //underline
-		
-		DOM SET XML ATTRIBUTE:C866($Txt_textID;\
-			"text-decoration";"underline")
-		$Lon_fonStyle:=$Lon_fonStyle-4
-		
+	If ($Lon_fontStyles ?? 0)
+		DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+			"font-weight"; "bold")
 	End if 
 	
-	If ($Lon_fonStyle>=2)  //italic
-		
-		DOM SET XML ATTRIBUTE:C866($Txt_textID;\
-			"font-style";"italic")
-		$Lon_fonStyle:=$Lon_fonStyle-2
-		
-	End if 
+	//Invisible characters are not treated properly
+	//So they were  replaced {
+	$Txt_string:=Replace string:C233($Txt_string; "  "; "==")
+	$Txt_string:=Replace string:C233($Txt_string; "\t"; "====")
+	//}
 	
-	If ($Lon_fonStyle=1)  //bold
-		
-		DOM SET XML ATTRIBUTE:C866($Txt_textID;\
-			"font-weight";"bold")
-		
-	End if 
+	DOM SET XML ELEMENT VALUE:C868($Txt_textID; $Txt_string)
 	
-	  //Invisible characters are not treated properly
-	  //So they were  replaced {
-	$Txt_string:=Replace string:C233($Txt_string;"  ";"==")
-	$Txt_string:=Replace string:C233($Txt_string;"\t";"====")
-	  //}
-	
-	DOM SET XML ELEMENT VALUE:C868($Txt_textID;$Txt_string)
-	
-	SVG EXPORT TO PICTURE:C1017($Txt_rootReference;$Pic_buffer)
-	PICTURE PROPERTIES:C457($Pic_buffer;$Num_width;$Lon_height;$Lon_Unused;$Lon_Unused;$Lon_Unused)
+	SVG EXPORT TO PICTURE:C1017($Txt_rootReference; $Pic_buffer)
+	PICTURE PROPERTIES:C457($Pic_buffer; $Num_width; $Lon_height; $Lon_Unused; $Lon_Unused; $Lon_Unused)
 	$Pic_buffer:=$Pic_buffer*0
 	
 	$0:=$Num_width

--- a/Project/Sources/Methods/SVG_New_text.4dm
+++ b/Project/Sources/Methods/SVG_New_text.4dm
@@ -1,11 +1,11 @@
 //%attributes = {"invisible":true,"shared":true,"preemptive":"capable"}
-  // ----------------------------------------------------
-  // Method : SVG_New_text
-  // Created 23/01/08 by Vincent de Lachaux
-  // ----------------------------------------------------
-  // Description
-  // Draw a text in a picture
-  // ----------------------------------------------------
+// ----------------------------------------------------
+// Method : SVG_New_text
+// Created 23/01/08 by Vincent de Lachaux
+// ----------------------------------------------------
+// Description
+// Draw a text in a picture
+// ----------------------------------------------------
 C_TEXT:C284($0)
 C_TEXT:C284($1)
 C_TEXT:C284($2)
@@ -21,30 +21,30 @@ C_REAL:C285($11)
 C_REAL:C285($12)
 
 C_BOOLEAN:C305($Boo_styledText)
-C_LONGINT:C283($Lon_Aligment;$Lon_count;$Lon_error;$Lon_Font_Size;$Lon_i;$Lon_lineFontSize)
-C_LONGINT:C283($Lon_opacity;$Lon_parameters;$Lon_Styles;$Lon_x)
-C_REAL:C285($Num_interlining;$Num_rotation;$Num_stretch;$Num_x;$Num_y)
-C_TEXT:C284($Dom_buffer;$Dom_svgObject;$Dom_svgReference;$kTxt_currentMethod;$Txt_Buffer;$Txt_Color)
-C_TEXT:C284($Txt_Font_Name;$Txt_pattern;$Txt_Span;$Txt_style;$Txt_text;$Txt_Transform)
+C_LONGINT:C283($Lon_Aligment; $Lon_count; $Lon_error; $Lon_Font_Size; $Lon_i; $Lon_lineFontSize)
+C_LONGINT:C283($Lon_opacity; $Lon_parameters; $Lon_fontStyles; $Lon_x)
+C_REAL:C285($Num_interlining; $Num_rotation; $Num_stretch; $Num_x; $Num_y)
+C_TEXT:C284($Dom_buffer; $Dom_svgObject; $Dom_svgReference; $kTxt_currentMethod; $Txt_Buffer; $Txt_Color)
+C_TEXT:C284($Txt_Font_Name; $Txt_pattern; $Txt_Span; $Txt_style; $Txt_text; $Txt_Transform)
 C_TEXT:C284($Txt_unit)
 
 If (False:C215)
-	C_TEXT:C284(SVG_New_text ;$0)
-	C_TEXT:C284(SVG_New_text ;$1)
-	C_TEXT:C284(SVG_New_text ;$2)
-	C_REAL:C285(SVG_New_text ;$3)
-	C_REAL:C285(SVG_New_text ;$4)
-	C_TEXT:C284(SVG_New_text ;$5)
-	C_LONGINT:C283(SVG_New_text ;$6)
-	C_LONGINT:C283(SVG_New_text ;$7)
-	C_LONGINT:C283(SVG_New_text ;$8)
-	C_TEXT:C284(SVG_New_text ;$9)
-	C_REAL:C285(SVG_New_text ;$10)
-	C_REAL:C285(SVG_New_text ;$11)
-	C_REAL:C285(SVG_New_text ;$12)
+	C_TEXT:C284(SVG_New_text; $0)
+	C_TEXT:C284(SVG_New_text; $1)
+	C_TEXT:C284(SVG_New_text; $2)
+	C_REAL:C285(SVG_New_text; $3)
+	C_REAL:C285(SVG_New_text; $4)
+	C_TEXT:C284(SVG_New_text; $5)
+	C_LONGINT:C283(SVG_New_text; $6)
+	C_LONGINT:C283(SVG_New_text; $7)
+	C_LONGINT:C283(SVG_New_text; $8)
+	C_TEXT:C284(SVG_New_text; $9)
+	C_REAL:C285(SVG_New_text; $10)
+	C_REAL:C285(SVG_New_text; $11)
+	C_REAL:C285(SVG_New_text; $12)
 End if 
 
-Compiler_SVG 
+Compiler_SVG
 
 $Lon_parameters:=Count parameters:C259
 $kTxt_currentMethod:="SVG_New_text"  //Nom methode courante
@@ -52,7 +52,7 @@ $kTxt_currentMethod:="SVG_New_text"  //Nom methode courante
 If ($Lon_parameters>=2)
 	
 	$Lon_Font_Size:=-1
-	$Lon_Styles:=-1
+	$Lon_fontStyles:=-1
 	$Lon_Aligment:=-1
 	$Num_interlining:=1
 	$Num_stretch:=1
@@ -60,14 +60,14 @@ If ($Lon_parameters>=2)
 	$Dom_svgObject:=$1
 	$Txt_text:=$2  //String to write
 	
-	  //#20-11-2014 - Accept styled text
-	  //#ACI0093459
-	  //$Boo_styledText:=(Position("<SPAN ";$Txt_text)>0)
-	$Boo_styledText:=str_styledText ($Txt_text)
+	//#20-11-2014 - Accept styled text
+	//#ACI0093459
+	//$Boo_styledText:=(Position("<SPAN ";$Txt_text)>0)
+	$Boo_styledText:=str_styledText($Txt_text)
 	
 	If (Storage:C1525.svg.options ?? 13)
 		
-		$Txt_text:=Replace string:C233($Txt_text;" ";Char:C90(0x2001))
+		$Txt_text:=Replace string:C233($Txt_text; " "; Char:C90(0x2001))
 		
 	End if 
 	
@@ -81,9 +81,9 @@ If ($Lon_parameters>=2)
 			
 			If ($Lon_parameters>=5)
 				
-				If (Position:C15("{";$5)=1)  //Embedded style
+				If (Position:C15("{"; $5)=1)  //Embedded style
 					
-					$Txt_style:=Replace string:C233(Substring:C12($5;2);"}";"")
+					$Txt_style:=Replace string:C233(Substring:C12($5; 2); "}"; "")
 					
 				Else 
 					
@@ -95,7 +95,7 @@ If ($Lon_parameters>=2)
 						
 						If ($Lon_parameters>=7)
 							
-							$Lon_Styles:=$7  //Default is standard
+							$Lon_fontStyles:=$7  //Default is standard
 							
 							If ($Lon_parameters>=8)
 								
@@ -135,8 +135,8 @@ If ($Lon_parameters>=2)
 			
 			If (False:C215)
 				
-				  //#TO_BE_DONE
-				  //we must find the inherited font size (class or parent)
+				//#TO_BE_DONE
+				//we must find the inherited font size (class or parent)
 				
 			Else 
 				
@@ -144,21 +144,21 @@ If ($Lon_parameters>=2)
 			End if 
 		End if 
 		
-		  // #30-9-2015 - Bug JFR [
-		  //$Num_y:=$Num_y+($Lon_Font_Size*Num(Not($Boo_styledText)))
+		// #30-9-2015 - Bug JFR [
+		//$Num_y:=$Num_y+($Lon_Font_Size*Num(Not($Boo_styledText)))
 		
 	Else 
 		
-		ARRAY LONGINT:C221($tLon_positions;0x0000)
-		ARRAY LONGINT:C221($tLon_lengths;0x0000)
+		ARRAY LONGINT:C221($tLon_positions; 0x0000)
+		ARRAY LONGINT:C221($tLon_lengths; 0x0000)
 		
-		If (Match regex:C1019("(?mi-s)font-size:(\\d*)([^;}]*)";$Txt_style;1;$tLon_positions;$tLon_lengths))
+		If (Match regex:C1019("(?mi-s)font-size:(\\d*)([^;}]*)"; $Txt_style; 1; $tLon_positions; $tLon_lengths))
 			
-			$Lon_Font_Size:=Num:C11(Substring:C12($Txt_style;$tLon_positions{1};$tLon_lengths{1}))
+			$Lon_Font_Size:=Num:C11(Substring:C12($Txt_style; $tLon_positions{1}; $tLon_lengths{1}))
 			
 			If (Size of array:C274($tLon_positions)>1)
 				
-				$Txt_unit:=Substring:C12($Txt_style;$tLon_positions{2};$tLon_lengths{2})
+				$Txt_unit:=Substring:C12($Txt_style; $tLon_positions{2}; $tLon_lengths{2})
 				
 			End if 
 		End if 
@@ -166,68 +166,68 @@ If ($Lon_parameters>=2)
 	
 	$Num_y:=$Num_y+($Lon_Font_Size*Num:C11(Not:C34($Boo_styledText)))  //]
 	
-	If (Asserted:C1132(xml_referenceValid ($Dom_svgObject);Get localized string:C991("error_badReference")))
+	If (Asserted:C1132(xml_referenceValid($Dom_svgObject); Get localized string:C991("error_badReference")))
 		
-		Component_errorHandler ("init";$kTxt_currentMethod)
+		Component_errorHandler("init"; $kTxt_currentMethod)
 		
-		$Dom_svgReference:=DOM Create XML element:C865($Dom_svgObject;"text")
+		$Dom_svgReference:=DOM Create XML element:C865($Dom_svgObject; "text")
 		
 		If (OK=1)
 			
 			If ($Num_x#0)\
 				 | ($Num_y#0)
 				
-				DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-					"x";$Num_x;\
-					"y";$Num_y)
+				DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+					"x"; $Num_x; \
+					"y"; $Num_y)
 				
 			End if 
 			
 			If (Length:C16($Txt_style)>0)  //Embedded style
 				
-				DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-					"style";$Txt_style)
+				DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+					"style"; $Txt_style)
 				
 			Else 
 				
 				Case of   //font-family
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | (Length:C16($Txt_Font_Name)=0)
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						$Txt_Font_Name:=fontReplaceArial ($Txt_Font_Name)
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"font-family";$Txt_Font_Name)
+						$Txt_Font_Name:=fontReplaceArial($Txt_Font_Name)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"font-family"; $Txt_Font_Name)
 						
-						  //.....................................................
+						//.....................................................
 				End case 
 				
 				Case of   //fill (color)
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | (Length:C16($Txt_Color)=0)
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						$Lon_x:=Position:C15(":";$Txt_Color)
+						$Lon_x:=Position:C15(":"; $Txt_Color)
 						
 						If ($Lon_x>0)
 							
-							$Lon_opacity:=Num:C11(Substring:C12($Txt_Color;$Lon_x+1))
-							$Txt_Color:=Lowercase:C14(Substring:C12($Txt_Color;1;$Lon_x-1))
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"fill";$Txt_Color)
+							$Lon_opacity:=Num:C11(Substring:C12($Txt_Color; $Lon_x+1))
+							$Txt_Color:=Lowercase:C14(Substring:C12($Txt_Color; 1; $Lon_x-1))
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"fill"; $Txt_Color)
 							
 							If (OK=1)
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"fill-opacity";$Lon_opacity/100)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"fill-opacity"; $Lon_opacity/100)
 								
 							End if 
 							
@@ -235,131 +235,121 @@ If ($Lon_parameters>=2)
 							
 							If ($Txt_Color="url(@")
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"fill";$Txt_Color)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"fill"; $Txt_Color)
 								
 							Else 
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"fill";Lowercase:C14($Txt_Color))
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"fill"; Lowercase:C14($Txt_Color))
 								
 							End if 
 						End if 
 						
-						  //.....................................................
+						//.....................................................
 				End case 
 				
 				Case of   //text-decoration, font-style & font-weight
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
-						 | ($Lon_Styles<0)
+						 | ($Lon_fontStyles<0)
 						
-						  //.....................................................
-					: ($Lon_Styles=0)
+						//.....................................................
+					: ($Lon_fontStyles=0)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-decoration";"none")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-decoration"; "none")
 						
 						If (OK=1)
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-style";"normal")
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"font-style"; "normal")
 							
 							If (OK=1)
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"font-weight";"normal")
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"font-weight"; "normal")
 								
 							End if 
 						End if 
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						If ($Lon_Styles>=8)  //line-through
-							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-decoration";"line-through")
-							
-							$Lon_Styles:=$Lon_Styles-8
-							
+						Case of 
+							: ($Lon_fontStyles ?? 2) & ($Lon_fontStyles ?? 3)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+									"text-decoration"; "underline line-through")
+								
+							: ($Lon_fontStyles ?? 2)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+									"text-decoration"; "underline")
+								
+							: ($Lon_fontStyles ?? 3)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+									"text-decoration"; "line-through")
+						End case 
+						
+						If ($Lon_fontStyles ?? 1)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+								"font-style"; "italic")
 						End if 
 						
-						If ($Lon_Styles>=4)  //underline
-							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-decoration";"underline")
-							
-							$Lon_Styles:=$Lon_Styles-4
-							
+						If ($Lon_fontStyles ?? 0)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+								"font-weight"; "bold")
 						End if 
 						
-						If ($Lon_Styles>=2)  //italic
-							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-style";"italic")
-							
-							$Lon_Styles:=$Lon_Styles-2
-							
-						End if 
-						
-						If ($Lon_Styles=1)  //bold
-							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-weight";"bold")
-							
-						End if 
-						
-						  //.....................................................
+						//.....................................................
 				End case 
 				
 				Case of   //font-size
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | ($Lon_Font_Size<0)
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"font-size";$Lon_Font_Size)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"font-size"; $Lon_Font_Size)
 						
-						  //.....................................................
+						//.....................................................
 				End case 
 				
 				Case of   //text-anchor
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | ($Lon_Aligment<0)
 						
-						  //.....................................................
+						//.....................................................
 					: ($Lon_Aligment=Align center:K42:3)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-anchor";"middle")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-anchor"; "middle")
 						
-						  //.....................................................
+						//.....................................................
 					: ($Lon_Aligment=Align right:K42:4)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-anchor";"end")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-anchor"; "end")
 						
-						  //.....................................................
+						//.....................................................
 					: ($Lon_Aligment=Align left:K42:2)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-anchor";"start")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-anchor"; "start")
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-anchor";"inherit")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-anchor"; "inherit")
 						
-						  //.....................................................
+						//.....................................................
 				End case 
 			End if 
 			
@@ -369,39 +359,39 @@ If ($Lon_parameters>=2)
 					
 					If ($Boo_styledText)
 						
-						  //$Txt_pattern:="(?m-is)(<span)( style=\"[^\"]*\">)(.*)(</span>)"
-						  //$Txt_replacement:="<_SPAN\\2\\3\\r</_SPAN>"
+						//$Txt_pattern:="(?m-is)(<span)( style=\"[^\"]*\">)(.*)(</span>)"
+						//$Txt_replacement:="<_SPAN\\2\\3\\r</_SPAN>"
 						
-						  //$Lon_error:=Rgx_SubstituteText ($Txt_pattern;$Txt_replacement;->$Txt_text)
+						//$Lon_error:=Rgx_SubstituteText ($Txt_pattern;$Txt_replacement;->$Txt_text)
 						
-						$Txt_text:=Replace string:C233($Txt_text;"<SPAN";"<tspan")
-						$Txt_text:=Replace string:C233($Txt_text;"</SPAN>";"</tspan>")
-						$Txt_text:=Replace string:C233($Txt_text;"STYLE=";"style=")
-						$Txt_text:=Replace string:C233($Txt_text;"color:";"fill:")
-						$Txt_text:=Replace string:C233($Txt_text;"<BR/>";"\r")
+						$Txt_text:=Replace string:C233($Txt_text; "<SPAN"; "<tspan")
+						$Txt_text:=Replace string:C233($Txt_text; "</SPAN>"; "</tspan>")
+						$Txt_text:=Replace string:C233($Txt_text; "STYLE="; "style=")
+						$Txt_text:=Replace string:C233($Txt_text; "color:"; "fill:")
+						$Txt_text:=Replace string:C233($Txt_text; "<BR/>"; "\r")
 						
 						$Txt_pattern:="(?mi-s)<tspan[^>]*style=\"font-size:(\\d+)[^>]*>"
 						
 						Repeat 
 							
-							$Lon_x:=Position:C15("\r";$Txt_text)
+							$Lon_x:=Position:C15("\r"; $Txt_text)
 							
 							If ($Lon_x>0)
 								
-								$Txt_Buffer:=Substring:C12($Txt_text;1;$Lon_x-1)
-								$Txt_text:=Delete string:C232($Txt_text;1;Length:C16($Txt_Buffer)+1)
+								$Txt_Buffer:=Substring:C12($Txt_text; 1; $Lon_x-1)
+								$Txt_text:=Delete string:C232($Txt_text; 1; Length:C16($Txt_Buffer)+1)
 								
-								  //#ACI0093774
-								  //$Txt_Span:=DOM Create XML element($Dom_svgReference;"tspan";"x";$Num_x)
+								//#ACI0093774
+								//$Txt_Span:=DOM Create XML element($Dom_svgReference;"tspan";"x";$Num_x)
 								
 								If (OK=1)
 									
-									ARRAY TEXT:C222($tTxt_results;0x0000)
+									ARRAY TEXT:C222($tTxt_results; 0x0000)
 									$Lon_lineFontSize:=$Lon_Font_Size  //default
 									
-									If (Rgx_ExtractText ($Txt_pattern;$Txt_Buffer;"";->$tTxt_results;0)=0)
+									If (Rgx_ExtractText($Txt_pattern; $Txt_Buffer; ""; ->$tTxt_results; 0)=0)
 										
-										For ($Lon_i;1;Size of array:C274($tTxt_results);1)
+										For ($Lon_i; 1; Size of array:C274($tTxt_results); 1)
 											
 											If (Num:C11($tTxt_results{$Lon_i})>$Lon_lineFontSize)
 												
@@ -411,24 +401,24 @@ If ($Lon_parameters>=2)
 										End for 
 									End if 
 									
-									$Num_y:=$Num_y+$Lon_lineFontSize+Choose:C955($Lon_count>0;$Num_interlining*8;0)
+									$Num_y:=$Num_y+$Lon_lineFontSize+Choose:C955($Lon_count>0; $Num_interlining*8; 0)
 									
-									  //#ACI0093774
-									  //DOM SET XML ATTRIBUTE($Txt_Span;"y";$Num_y)
-									  //DOM SET XML ELEMENT VALUE($Txt_Span;$Txt_Buffer)
+									//#ACI0093774
+									//DOM SET XML ATTRIBUTE($Txt_Span;"y";$Num_y)
+									//DOM SET XML ELEMENT VALUE($Txt_Span;$Txt_Buffer)
 									
-									  //#ACI0096676 {
-									  //$Lon_error:=Rgx_SubstituteText ("(?mi-s)^<tspan ([^>]*>)";"<tspan x=\""+String($Num_x)+"\" y=\""+String($Num_y)+"\" \\1";->$Txt_Buffer)
+									//#ACI0096676 {
+									//$Lon_error:=Rgx_SubstituteText ("(?mi-s)^<tspan ([^>]*>)";"<tspan x=\""+String($Num_x)+"\" y=\""+String($Num_y)+"\" \\1";->$Txt_Buffer)
 									If ($Txt_Buffer#"<tspan@")
 										
 										$Txt_Buffer:="<tspan>"+$Txt_Buffer+"</tspan>"
 										
 									End if 
 									
-									$Lon_error:=Rgx_SubstituteText ("(?mi-s)^<tspan([^>]*>)";"<tspan x=\""+String:C10($Num_x)+"\" y=\""+String:C10($Num_y)+"\" \\1";->$Txt_Buffer)
-									  //}
+									$Lon_error:=Rgx_SubstituteText("(?mi-s)^<tspan([^>]*>)"; "<tspan x=\""+String:C10($Num_x)+"\" y=\""+String:C10($Num_y)+"\" \\1"; ->$Txt_Buffer)
+									//}
 									
-									$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference;XML ELEMENT:K45:20;$Txt_Buffer)
+									$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference; XML ELEMENT:K45:20; $Txt_Buffer)
 									
 								End if 
 								
@@ -438,16 +428,16 @@ If ($Lon_parameters>=2)
 								
 								If ($Lon_Count=0)
 									
-									DOM SET XML ELEMENT VALUE:C868($Dom_svgReference;$Txt_text)
+									DOM SET XML ELEMENT VALUE:C868($Dom_svgReference; $Txt_text)
 									
 								Else 
 									
-									ARRAY TEXT:C222($tTxt_results;0x0000)
+									ARRAY TEXT:C222($tTxt_results; 0x0000)
 									$Lon_lineFontSize:=$Lon_Font_Size  //default
 									
-									If (Rgx_ExtractText ($Txt_pattern;$Txt_text;"";->$tTxt_results;0)=0)
+									If (Rgx_ExtractText($Txt_pattern; $Txt_text; ""; ->$tTxt_results; 0)=0)
 										
-										For ($Lon_i;1;Size of array:C274($tTxt_results);1)
+										For ($Lon_i; 1; Size of array:C274($tTxt_results); 1)
 											
 											If (Num:C11($tTxt_results{$Lon_i})>$Lon_lineFontSize)
 												
@@ -457,26 +447,26 @@ If ($Lon_parameters>=2)
 										End for 
 									End if 
 									
-									$Num_y:=$Num_y+$Lon_lineFontSize+Choose:C955($Lon_count>0;$Num_interlining*8;0)
+									$Num_y:=$Num_y+$Lon_lineFontSize+Choose:C955($Lon_count>0; $Num_interlining*8; 0)
 									
-									  //#ACI0093774
-									  //$Txt_Span:=DOM Create XML element($Dom_svgReference;"tspan";"x";$Num_x;"y";$Num_y)
-									  //If (OK=1)
-									  //DOM SET XML ELEMENT VALUE($Txt_Span;$Txt_text)
-									  //End if
+									//#ACI0093774
+									//$Txt_Span:=DOM Create XML element($Dom_svgReference;"tspan";"x";$Num_x;"y";$Num_y)
+									//If (OK=1)
+									//DOM SET XML ELEMENT VALUE($Txt_Span;$Txt_text)
+									//End if
 									
-									  //#ACI0096676 {
-									  //$Lon_error:=Rgx_SubstituteText ("(?mi-s)^<tspan ([^>]*>)";"<tspan x=\""+String($Num_x)+"\" y=\""+String($Num_y)+"\" \\1";->$Txt_text)
+									//#ACI0096676 {
+									//$Lon_error:=Rgx_SubstituteText ("(?mi-s)^<tspan ([^>]*>)";"<tspan x=\""+String($Num_x)+"\" y=\""+String($Num_y)+"\" \\1";->$Txt_text)
 									If ($Txt_Buffer#"<tspan@")
 										
 										$Txt_Buffer:="<tspan>"+$Txt_Buffer+"</tspan>"
 										
 									End if 
 									
-									$Lon_error:=Rgx_SubstituteText ("(?mi-s)^<tspan([^>]*>)";"<tspan x=\""+String:C10($Num_x)+"\" y=\""+String:C10($Num_y)+"\" \\1";->$Txt_Buffer)
-									  //}
+									$Lon_error:=Rgx_SubstituteText("(?mi-s)^<tspan([^>]*>)"; "<tspan x=\""+String:C10($Num_x)+"\" y=\""+String:C10($Num_y)+"\" \\1"; ->$Txt_Buffer)
+									//}
 									
-									$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference;XML ELEMENT:K45:20;$Txt_text)
+									$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference; XML ELEMENT:K45:20; $Txt_text)
 									
 								End if 
 							End if 
@@ -484,77 +474,77 @@ If ($Lon_parameters>=2)
 							 | (OK=0)
 						
 						
-						  //$Dom_buffer:=DOM Create XML Ref("root")
-						  //$Dom_:=DOM Append XML element($Dom_buffer;$Dom_svgReference)
+						//$Dom_buffer:=DOM Create XML Ref("root")
+						//$Dom_:=DOM Append XML element($Dom_buffer;$Dom_svgReference)
 						
-						  //DOM EXPORT TO VAR($Dom_buffer;$Txt_Buffer)
-						  //DOM CLOSE XML($Dom_buffer)
+						//DOM EXPORT TO VAR($Dom_buffer;$Txt_Buffer)
+						//DOM CLOSE XML($Dom_buffer)
 						
-						  //$Txt_Buffer:=Replace string($Txt_Buffer;"_SPAN";"tspan")
-						  //$Txt_Buffer:=Replace string($Txt_Buffer;" xmlns=\"\"";"")
+						//$Txt_Buffer:=Replace string($Txt_Buffer;"_SPAN";"tspan")
+						//$Txt_Buffer:=Replace string($Txt_Buffer;" xmlns=\"\"";"")
 						
-						  //$Dom_buffer:=DOM Parse XML variable($Txt_Buffer)
-						  //$Dom_:=DOM Find XML element($Dom_buffer;"root/text")
+						//$Dom_buffer:=DOM Parse XML variable($Txt_Buffer)
+						//$Dom_:=DOM Find XML element($Dom_buffer;"root/text")
 						
-						  //DOM REMOVE XML ELEMENT($Dom_svgReference)
-						  //$Dom_svgReference:=DOM Append XML element($Dom_svgObject;$Dom_)
+						//DOM REMOVE XML ELEMENT($Dom_svgReference)
+						//$Dom_svgReference:=DOM Append XML element($Dom_svgObject;$Dom_)
 						
 						
 						
 					Else 
 						
-						  // 25-1-2017 - Encode special characters
-						  // #ACI0097138
-						  //$Txt_text:=xml_Escape_characters ($Txt_text)
+						// 25-1-2017 - Encode special characters
+						// #ACI0097138
+						//$Txt_text:=xml_Escape_characters ($Txt_text)
 						
 						Repeat 
 							
-							$Lon_x:=Position:C15("\r";$Txt_text)
+							$Lon_x:=Position:C15("\r"; $Txt_text)
 							
 							If ($Lon_x>0)
 								
-								$Txt_Buffer:=Substring:C12($Txt_text;1;$Lon_x-1)
-								$Txt_Span:=DOM Create XML element:C865($Dom_svgReference;"tspan";\
-									"x";$Num_x)
+								$Txt_Buffer:=Substring:C12($Txt_text; 1; $Lon_x-1)
+								$Txt_Span:=DOM Create XML element:C865($Dom_svgReference; "tspan"; \
+									"x"; $Num_x)
 								
 								If (OK=1)
 									
-									DOM SET XML ATTRIBUTE:C866($Txt_Span;\
-										"y";$Num_y+($Lon_Font_Size*$Lon_Count*$Num_interlining))
-									DOM SET XML ELEMENT VALUE:C868($Txt_Span;$Txt_Buffer)
+									DOM SET XML ATTRIBUTE:C866($Txt_Span; \
+										"y"; $Num_y+($Lon_Font_Size*$Lon_Count*$Num_interlining))
+									DOM SET XML ELEMENT VALUE:C868($Txt_Span; $Txt_Buffer)
 									
 								End if 
 								
-								$Txt_text:=Delete string:C232($Txt_text;1;Length:C16($Txt_Buffer)+1)
+								$Txt_text:=Delete string:C232($Txt_text; 1; Length:C16($Txt_Buffer)+1)
 								$Lon_Count:=$Lon_Count+1
 								
 							Else 
 								
 								If ($Lon_Count=0)
 									
-									DOM SET XML ELEMENT VALUE:C868($Dom_svgReference;$Txt_text)
+									DOM SET XML ELEMENT VALUE:C868($Dom_svgReference; $Txt_text)
 									
 								Else 
 									
 									If ($Lon_Font_Size=-1)
 										
-										  //use em
-										$Txt_Span:=DOM Create XML element:C865($Dom_svgReference;"tspan";\
-											"x";$Num_x;\
-											"y";String:C10($Lon_Count+1)+"em")
+										//use em
+										$Txt_Span:=DOM Create XML element:C865($Dom_svgReference; "tspan"; \
+											"x"; $Num_x; \
+											"y"; String:C10($Lon_Count+1)+"em")
 										
 									Else 
 										
-										  //use pt
-										$Txt_Span:=DOM Create XML element:C865($Dom_svgReference;"tspan";\
-											"x";$Num_x;\
-											"y";$Num_y+($Lon_Font_Size*$Lon_Count*$Num_interlining))
+										//use pt
+										$Txt_Span:=DOM Create XML element:C865($Dom_svgReference; "tspan"; \
+											"x"; $Num_x; \
+											"y"; $Num_y+($Lon_Font_Size*$Lon_Count*$Num_interlining))
 										
 									End if 
 									
 									If (OK=1)
 										
-										DOM SET XML ELEMENT VALUE:C868($Txt_Span;$Txt_text)
+										DOM SET XML ELEMENT VALUE:C868($Txt_Span; $Txt_text)
 										
 									End if 
 								End if 
@@ -568,72 +558,72 @@ If ($Lon_parameters>=2)
 			
 			Case of 
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)\
 					 | ($Num_rotation=0)
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
 					If ($Num_rotation>0)
 						
-						$Txt_Transform:="rotate("+String:C10($Num_rotation;"&xml")+","+String:C10($Num_x;"&xml")+","+String:C10($Num_y;"&xml")+")"
-						$Txt_Buffer:=String:C10(-$Lon_Font_Size*$Lon_Count*$Num_interlining;"&xml")
-						$Txt_Transform:=$Txt_Transform+" translate("+String:C10(-$Lon_Font_Size;"&xml")+","+$Txt_Buffer+")"
+						$Txt_Transform:="rotate("+String:C10($Num_rotation; "&xml")+","+String:C10($Num_x; "&xml")+","+String:C10($Num_y; "&xml")+")"
+						$Txt_Buffer:=String:C10(-$Lon_Font_Size*$Lon_Count*$Num_interlining; "&xml")
+						$Txt_Transform:=$Txt_Transform+" translate("+String:C10(-$Lon_Font_Size; "&xml")+","+$Txt_Buffer+")"
 						
 					Else 
 						
-						  //•••••••••••••••••••••••••••••
-						  //#TO_BE_DONE  {
-						$Txt_Transform:="rotate("+String:C10($Num_rotation;"&xml")+")"
+						//•••••••••••••••••••••••••••••
+						//#TO_BE_DONE  {
+						$Txt_Transform:="rotate("+String:C10($Num_rotation; "&xml")+")"
 						
-						  //$Txt_Transform:="rotate("+Remplacer chaine(Chaine($Num_rotation);",";".")+","+Remplacer chaine(Chaine($Num_x);",";".")+","+Remplacer chaine(Chaine($Num_y);",";".")+")"
-						  //$Txt_Buffer:=Remplacer chaine(Chaine((-$Lon_Font_Size*$Lon_Count*$Num_interlining));",";".")
-						  //$Txt_Transform:=$Txt_Transform+" translate("+Remplacer chaine(Chaine(-$Lon_Font_Size);",";".")+","+$Txt_Buffer+")"
-						  //}
+						//$Txt_Transform:="rotate("+Remplacer chaine(Chaine($Num_rotation);",";".")+","+Remplacer chaine(Chaine($Num_x);",";".")+","+Remplacer chaine(Chaine($Num_y);",";".")+")"
+						//$Txt_Buffer:=Remplacer chaine(Chaine((-$Lon_Font_Size*$Lon_Count*$Num_interlining));",";".")
+						//$Txt_Transform:=$Txt_Transform+" translate("+Remplacer chaine(Chaine(-$Lon_Font_Size);",";".")+","+$Txt_Buffer+")"
+						//}
 						
 					End if 
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			Case of 
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)\
 					 | ($Num_stretch=1)
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
 					$Txt_Transform:=$Txt_Transform+(" "*Num:C11(Length:C16($Txt_Transform)>0))
-					$Txt_Transform:=$Txt_Transform+"scale("+String:C10($Num_stretch;"&xml")+",1)"
+					$Txt_Transform:=$Txt_Transform+"scale("+String:C10($Num_stretch; "&xml")+",1)"
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			Case of 
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)\
 					 | (Length:C16($Txt_Transform)=0)
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"transform";$Txt_Transform)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"transform"; $Txt_Transform)
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			If (OK=1)
 				
-				  //Set the id
+				//Set the id
 				If (Storage:C1525.svg.options ?? 1)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"id";$Dom_svgReference)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"id"; $Dom_svgReference)
 					
 				End if 
 				
@@ -645,16 +635,16 @@ If ($Lon_parameters>=2)
 			End if 
 		End if 
 		
-		ASSERT:C1129(Component_errorHandler ("deinit"))
+		ASSERT:C1129(Component_errorHandler("deinit"))
 		
 	Else 
 		
-		ASSERT:C1129(Component_putError (8852;$kTxt_currentMethod))  //The reference is not a svg object
+		ASSERT:C1129(Component_putError(8852; $kTxt_currentMethod))  //The reference is not a svg object
 		
 	End if 
 	
 Else 
 	
-	ASSERT:C1129(Component_putError (8850;$kTxt_currentMethod))  //Parameters Missing
+	ASSERT:C1129(Component_putError(8850; $kTxt_currentMethod))  //Parameters Missing
 	
 End if 

--- a/Project/Sources/Methods/SVG_New_textArea.4dm
+++ b/Project/Sources/Methods/SVG_New_textArea.4dm
@@ -1,21 +1,21 @@
 //%attributes = {"invisible":true,"shared":true,"preemptive":"capable"}
-  // ----------------------------------------------------
-  // Method : SVG_New_textArea
-  // Created 23/01/08 by Vincent de Lachaux
-  // ----------------------------------------------------
-  // Modified by Vincent de Lachaux (08/12/09)
-  // v12 : Treat the carriage returns as elements "tbreak"
-  // ----------------------------------------------------
-  // Modified by Vincent de Lachaux (04/07/11)
-  // Added alternative syntax to set embedded style
-  // SVG_New_textArea($Dom_svg;"Hello World !"; x ; y ; width ; height ; style_definition)
-  // ----------------------------------------------------
-  // Modified by Vincent de Lachaux (05/07/11)
-  // Support for styled text
-  // ----------------------------------------------------
-  // Description
-  // Draw a text as textArea in a picture
-  // ----------------------------------------------------
+// ----------------------------------------------------
+// Method : SVG_New_textArea
+// Created 23/01/08 by Vincent de Lachaux
+// ----------------------------------------------------
+// Modified by Vincent de Lachaux (08/12/09)
+// v12 : Treat the carriage returns as elements "tbreak"
+// ----------------------------------------------------
+// Modified by Vincent de Lachaux (04/07/11)
+// Added alternative syntax to set embedded style
+// SVG_New_textArea($Dom_svg;"Hello World !"; x ; y ; width ; height ; style_definition)
+// ----------------------------------------------------
+// Modified by Vincent de Lachaux (05/07/11)
+// Support for styled text
+// ----------------------------------------------------
+// Description
+// Draw a text as textArea in a picture
+// ----------------------------------------------------
 C_TEXT:C284($0)
 C_TEXT:C284($1)
 C_TEXT:C284($2)
@@ -28,26 +28,26 @@ C_LONGINT:C283($8)
 C_LONGINT:C283($9)
 C_LONGINT:C283($10)
 
-C_LONGINT:C283($Lon_Font_Size;$Lon_fontAlignment;$Lon_fontStyles;$Lon_opacity;$Lon_parameters;$Lon_x)
-C_REAL:C285($Num_height;$Num_width;$Num_x;$Num_y)
-C_TEXT:C284($Dom_buffer;$Dom_source;$Dom_svgObject;$Dom_svgReference;$kTxt_currentMethod;$Txt_Buffer)
-C_TEXT:C284($Txt_Color;$Txt_Font_Name;$Txt_style;$Txt_text)
+C_LONGINT:C283($Lon_Font_Size; $Lon_fontAlignment; $Lon_fontStyles; $Lon_opacity; $Lon_parameters; $Lon_x)
+C_REAL:C285($Num_height; $Num_width; $Num_x; $Num_y)
+C_TEXT:C284($Dom_buffer; $Dom_source; $Dom_svgObject; $Dom_svgReference; $kTxt_currentMethod; $Txt_Buffer)
+C_TEXT:C284($Txt_Color; $Txt_Font_Name; $Txt_style; $Txt_text)
 
 If (False:C215)
-	C_TEXT:C284(SVG_New_textArea ;$0)
-	C_TEXT:C284(SVG_New_textArea ;$1)
-	C_TEXT:C284(SVG_New_textArea ;$2)
-	C_REAL:C285(SVG_New_textArea ;$3)
-	C_REAL:C285(SVG_New_textArea ;$4)
-	C_REAL:C285(SVG_New_textArea ;$5)
-	C_REAL:C285(SVG_New_textArea ;$6)
-	C_TEXT:C284(SVG_New_textArea ;$7)
-	C_LONGINT:C283(SVG_New_textArea ;$8)
-	C_LONGINT:C283(SVG_New_textArea ;$9)
-	C_LONGINT:C283(SVG_New_textArea ;$10)
+	C_TEXT:C284(SVG_New_textArea; $0)
+	C_TEXT:C284(SVG_New_textArea; $1)
+	C_TEXT:C284(SVG_New_textArea; $2)
+	C_REAL:C285(SVG_New_textArea; $3)
+	C_REAL:C285(SVG_New_textArea; $4)
+	C_REAL:C285(SVG_New_textArea; $5)
+	C_REAL:C285(SVG_New_textArea; $6)
+	C_TEXT:C284(SVG_New_textArea; $7)
+	C_LONGINT:C283(SVG_New_textArea; $8)
+	C_LONGINT:C283(SVG_New_textArea; $9)
+	C_LONGINT:C283(SVG_New_textArea; $10)
 End if 
 
-Compiler_SVG 
+Compiler_SVG
 
 $Lon_parameters:=Count parameters:C259
 $kTxt_currentMethod:="SVG_New_textArea"  //Nom methode courante
@@ -65,7 +65,7 @@ If ($Lon_parameters>=2)
 	
 	If (Storage:C1525.svg.options ?? 13)
 		
-		$Txt_text:=Replace string:C233($Txt_text;" ";Char:C90(0x2001))
+		$Txt_text:=Replace string:C233($Txt_text; " "; Char:C90(0x2001))
 		
 	End if 
 	
@@ -87,9 +87,9 @@ If ($Lon_parameters>=2)
 					
 					If ($Lon_parameters>=7)
 						
-						If (Position:C15("{";$7)=1)  //Embedded style
+						If (Position:C15("{"; $7)=1)  //Embedded style
 							
-							$Txt_style:=Replace string:C233(Substring:C12($7;2);"}";"")
+							$Txt_style:=Replace string:C233(Substring:C12($7; 2); "}"; "")
 							
 						Else 
 							
@@ -117,33 +117,33 @@ If ($Lon_parameters>=2)
 		End if 
 	End if 
 	
-	If (Asserted:C1132(xml_referenceValid ($Dom_svgObject);Get localized string:C991("error_badReference")))
+	If (Asserted:C1132(xml_referenceValid($Dom_svgObject); Get localized string:C991("error_badReference")))
 		
-		Component_errorHandler ("init";$kTxt_currentMethod)
+		Component_errorHandler("init"; $kTxt_currentMethod)
 		
-		  //#ACI0099523
-		$Txt_text:=Replace string:C233($Txt_text;"\r\n";"\r")
+		//#ACI0099523
+		$Txt_text:=Replace string:C233($Txt_text; "\r\n"; "\r")
 		
-		  //#ACI0093459
-		  //If (Position("<SPAN ";$Txt_text)>0)  //Styled text
-		If (str_styledText ($Txt_text))  //Styled text
+		//#ACI0093459
+		//If (Position("<SPAN ";$Txt_text)>0)  //Styled text
+		If (str_styledText($Txt_text))  //Styled text
 			
-			$Txt_Buffer:=Replace string:C233($Txt_text;"<SPAN";"<tspan")
-			$Txt_Buffer:=Replace string:C233($Txt_Buffer;"</SPAN>";"</tspan>")
-			$Txt_Buffer:=Replace string:C233($Txt_Buffer;"STYLE=";"style=")
-			$Txt_Buffer:=Replace string:C233($Txt_Buffer;"color:";"fill:")
-			$Txt_Buffer:=Replace string:C233($Txt_Buffer;"<BR/>";"<tbreak/>")
+			$Txt_Buffer:=Replace string:C233($Txt_text; "<SPAN"; "<tspan")
+			$Txt_Buffer:=Replace string:C233($Txt_Buffer; "</SPAN>"; "</tspan>")
+			$Txt_Buffer:=Replace string:C233($Txt_Buffer; "STYLE="; "style=")
+			$Txt_Buffer:=Replace string:C233($Txt_Buffer; "color:"; "fill:")
+			$Txt_Buffer:=Replace string:C233($Txt_Buffer; "<BR/>"; "<tbreak/>")
 			$Txt_Buffer:="<svg xmlns='http://www.w3.org/2000/svg'><textArea>"+$Txt_Buffer+"</textArea></svg>"
 			
 			$Dom_buffer:=DOM Parse XML variable:C720($Txt_Buffer)
 			
 			If (OK=1)
 				
-				$Dom_source:=DOM Find XML element:C864($Dom_buffer;"/svg/textArea")
+				$Dom_source:=DOM Find XML element:C864($Dom_buffer; "/svg/textArea")
 				
 				If (OK=1)
 					
-					$Dom_svgReference:=DOM Append XML element:C1082($Dom_svgObject;$Dom_source)
+					$Dom_svgReference:=DOM Append XML element:C1082($Dom_svgObject; $Dom_source)
 					
 				End if 
 				
@@ -153,48 +153,48 @@ If ($Lon_parameters>=2)
 			
 		Else 
 			
-			  // 25-1-2017 - Encode special characters
-			  // #ACI0097138
-			  //$Txt_text:=xml_Escape_characters ($Txt_text)
+			// 25-1-2017 - Encode special characters
+			// #ACI0097138
+			//$Txt_text:=xml_Escape_characters ($Txt_text)
 			
-			$Dom_svgReference:=DOM Create XML element:C865($Dom_svgObject;"textArea")
+			$Dom_svgReference:=DOM Create XML element:C865($Dom_svgObject; "textArea")
 			
 			If (OK=1)\
 				 & (Length:C16($Txt_text)>0)
 				
-				  // v12 : Treat the carriage returns as elements "tbreak"
-				  //{------------------------------------------------------------------
-				  //DOM ECRIRE VALEUR ELEMENT XML($Txt_nodeReference;$Txt_stringToWrite)
+				// v12 : Treat the carriage returns as elements "tbreak"
+				//{------------------------------------------------------------------
+				//DOM ECRIRE VALEUR ELEMENT XML($Txt_nodeReference;$Txt_stringToWrite)
 				
 				Repeat 
 					
-					$Lon_x:=Position:C15("\r";$Txt_text)
+					$Lon_x:=Position:C15("\r"; $Txt_text)
 					
 					If ($Lon_x=0)
 						
-						$Lon_x:=Position:C15("\n";$Txt_text)
+						$Lon_x:=Position:C15("\n"; $Txt_text)
 						
 					End if 
 					
 					If ($Lon_x>0)
 						
-						$Txt_Buffer:=Substring:C12($Txt_text;1;$Lon_x-1)
+						$Txt_Buffer:=Substring:C12($Txt_text; 1; $Lon_x-1)
 						
 						If (Length:C16($Txt_Buffer)>0)
 							
-							$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference;XML DATA:K45:12;$Txt_Buffer)
+							$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference; XML DATA:K45:12; $Txt_Buffer)
 							
 						End if 
 						
-						$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference;XML ELEMENT:K45:20;"tbreak")
+						$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference; XML ELEMENT:K45:20; "tbreak")
 						
-						$Txt_text:=Delete string:C232($Txt_text;1;Length:C16($Txt_Buffer)+1)
+						$Txt_text:=Delete string:C232($Txt_text; 1; Length:C16($Txt_Buffer)+1)
 						
 					Else 
 						
 						If (Length:C16($Txt_text)>0)
 							
-							$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference;XML DATA:K45:12;$Txt_text)
+							$Dom_buffer:=DOM Append XML child node:C1080($Dom_svgReference; XML DATA:K45:12; $Txt_text)
 							
 						End if 
 					End if 
@@ -210,97 +210,97 @@ If ($Lon_parameters>=2)
 				 & (($Num_x#0)\
 				 | ($Num_y#0))
 				
-				DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-					"x";$Num_x;\
-					"y";$Num_y)
+				DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+					"x"; $Num_x; \
+					"y"; $Num_y)
 				
 			End if 
 			
 			Case of   //width
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)
 					
-					  //.....................................................
+					//.....................................................
 				: ($Num_width=-1)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"width";"auto")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"width"; "auto")
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"width";$Num_width)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"width"; $Num_width)
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			Case of   //height
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)
 					
-					  //.....................................................
+					//.....................................................
 				: ($Num_height=-1)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"height";"auto")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"height"; "auto")
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"height";$Num_height)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"height"; $Num_height)
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			If (Length:C16($Txt_style)>0)  //Embedded style
 				
-				DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-					"style";$Txt_style)
+				DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+					"style"; $Txt_style)
 				
 			Else 
 				
 				Case of   //font-family
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | (Length:C16($Txt_Font_Name)=0)
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						$Txt_Font_Name:=fontReplaceArial ($Txt_Font_Name)
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"font-family";$Txt_Font_Name)
+						$Txt_Font_Name:=fontReplaceArial($Txt_Font_Name)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"font-family"; $Txt_Font_Name)
 						
-						  //.....................................................
+						//.....................................................
 				End case 
 				
 				Case of   //fill (color)
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | (Length:C16($Txt_Color)=0)
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						$Lon_x:=Position:C15(":";$Txt_Color)
+						$Lon_x:=Position:C15(":"; $Txt_Color)
 						
 						If ($Lon_x>0)
 							
-							$Lon_opacity:=Num:C11(Substring:C12($Txt_Color;$Lon_x+1))
-							$Txt_Color:=Lowercase:C14(Substring:C12($Txt_Color;1;$Lon_x-1))
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"fill";$Txt_Color)
+							$Lon_opacity:=Num:C11(Substring:C12($Txt_Color; $Lon_x+1))
+							$Txt_Color:=Lowercase:C14(Substring:C12($Txt_Color; 1; $Lon_x-1))
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"fill"; $Txt_Color)
 							
 							If (OK=1)
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"fill-opacity";$Lon_opacity/100)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"fill-opacity"; $Lon_opacity/100)
 								
 							End if 
 							
@@ -308,149 +308,142 @@ If ($Lon_parameters>=2)
 							
 							If ($Txt_Color="url(@")
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"fill";$Txt_Color)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"fill"; $Txt_Color)
 								
 							Else 
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"fill";Lowercase:C14($Txt_Color))
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"fill"; Lowercase:C14($Txt_Color))
 								
 							End if 
 						End if 
 						
-						  //.....................................................
+						//.....................................................
 				End case 
 				
 				Case of   //text-decoration, font-style & font-weight
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | ($Lon_fontStyles<0)
 						
-						  //.....................................................
+						//.....................................................
 					: ($Lon_fontStyles=0)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-decoration";"none")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-decoration"; "none")
 						
 						If (OK=1)
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-style";"normal")
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"font-style"; "normal")
 							
 							If (OK=1)
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"font-weight";"normal")
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"font-weight"; "normal")
 								
 							End if 
 						End if 
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						If ($Lon_fontStyles>=8)  //line-through
-							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-decoration";"line-through")
-							$Lon_fontStyles:=$Lon_fontStyles-8
-							
+						Case of 
+							: ($Lon_fontStyles ?? 2) & ($Lon_fontStyles ?? 3)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+									"text-decoration"; "underline line-through")
+								
+							: ($Lon_fontStyles ?? 2)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+									"text-decoration"; "underline")
+								
+							: ($Lon_fontStyles ?? 3)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+									"text-decoration"; "line-through")
+						End case 
+						
+						If ($Lon_fontStyles ?? 1)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+								"font-style"; "italic")
 						End if 
 						
-						If ($Lon_fontStyles>=4)  //underline
-							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-decoration";"underline")
-							$Lon_fontStyles:=$Lon_fontStyles-4
-							
+						If ($Lon_fontStyles ?? 0)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+								"font-weight"; "bold")
 						End if 
 						
-						If ($Lon_fontStyles>=2)  //italic
-							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-style";"italic")
-							$Lon_fontStyles:=$Lon_fontStyles-2
-							
-						End if 
-						
-						If ($Lon_fontStyles=1)  //bold
-							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-weight";"bold")
-							
-						End if 
-						
-						  //.....................................................
+						//.....................................................
 				End case 
 				
 				Case of   //font-size
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | ($Lon_Font_Size<0)
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"font-size";$Lon_Font_Size)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"font-size"; $Lon_Font_Size)
 						
-						  //.....................................................
+						//.....................................................
 				End case 
 				
 				Case of   //text-align
 						
-						  //.....................................................
+						//.....................................................
 					: (OK=0)\
 						 | ($Lon_fontAlignment<0)
 						
-						  //.....................................................
+						//.....................................................
 					: ($Lon_fontAlignment=Align center:K42:3)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-align";"center")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-align"; "center")
 						
-						  //.....................................................
+						//.....................................................
 					: ($Lon_fontAlignment=Align right:K42:4)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-align";"end")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-align"; "end")
 						
-						  //.....................................................
+						//.....................................................
 					: ($Lon_fontAlignment=Align left:K42:2)\
 						 | ($Lon_fontAlignment=Align default:K42:1)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-align";"start")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-align"; "start")
 						
-						  //.....................................................
+						//.....................................................
 					: ($Lon_fontAlignment=5)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-align";"justify")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-align"; "justify")
 						
-						  //.....................................................
+						//.....................................................
 					Else 
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-align";"inherit")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"text-align"; "inherit")
 						
-						  //.....................................................
+						//.....................................................
 				End case 
 			End if 
 			
-			  //------------------------------------------------------------------}
+			//------------------------------------------------------------------}
 			
 		End if 
 		
 		If (OK=1)
 			
-			  //Set the id
+			//Set the id
 			If (Storage:C1525.svg.options ?? 1)
 				
-				DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-					"id";$Dom_svgReference)
+				DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+					"id"; $Dom_svgReference)
 				
 			End if 
 			
@@ -461,16 +454,16 @@ If ($Lon_parameters>=2)
 			End if 
 		End if 
 		
-		ASSERT:C1129(Component_errorHandler ("deinit"))
+		ASSERT:C1129(Component_errorHandler("deinit"))
 		
 	Else 
 		
-		ASSERT:C1129(Component_putError (8852;$kTxt_currentMethod))  //The reference is not a svg object
+		ASSERT:C1129(Component_putError(8852; $kTxt_currentMethod))  //The reference is not a svg object
 		
 	End if 
 	
 Else 
 	
-	ASSERT:C1129(Component_putError (8850;$kTxt_currentMethod))  //Parameters Missing
+	ASSERT:C1129(Component_putError(8850; $kTxt_currentMethod))  //Parameters Missing
 	
 End if 

--- a/Project/Sources/Methods/SVG_New_tspan.4dm
+++ b/Project/Sources/Methods/SVG_New_tspan.4dm
@@ -1,16 +1,16 @@
 //%attributes = {"invisible":true,"shared":true,"preemptive":"capable"}
-  // ----------------------------------------------------
-  // Method : SVG_New_tspan
-  // Created 18/07/08 by Vincent de Lachaux
-  // ----------------------------------------------------
-  // Modified by Vincent de Lachaux (04/07/11)
-  // 1] now allowed with textArea
-  // 2] Added alternative syntax to set embedded style
-  // SVG_New_tspan($Dom_svg;"Hello World !"; x ; y ; style_definition)
-  // ----------------------------------------------------
-  // Description
-  // Create a tspan node
-  // ----------------------------------------------------
+// ----------------------------------------------------
+// Method : SVG_New_tspan
+// Created 18/07/08 by Vincent de Lachaux
+// ----------------------------------------------------
+// Modified by Vincent de Lachaux (04/07/11)
+// 1] now allowed with textArea
+// 2] Added alternative syntax to set embedded style
+// SVG_New_tspan($Dom_svg;"Hello World !"; x ; y ; style_definition)
+// ----------------------------------------------------
+// Description
+// Create a tspan node
+// ----------------------------------------------------
 C_TEXT:C284($0)
 C_TEXT:C284($1)
 C_TEXT:C284($2)
@@ -22,25 +22,25 @@ C_LONGINT:C283($7)
 C_LONGINT:C283($8)
 C_TEXT:C284($9)
 
-C_LONGINT:C283($Lon_Aligment;$Lon_Font_Size;$Lon_opacity;$Lon_parameters;$Lon_Styles;$Lon_x)
-C_REAL:C285($Num_interlining;$Num_stretch;$Num_x;$Num_y)
-C_TEXT:C284($Dom_svgObject;$Dom_svgReference;$kTxt_currentMethod;$Txt_Color;$Txt_Font_Name;$Txt_Name)
-C_TEXT:C284($Txt_style;$Txt_text)
+C_LONGINT:C283($Lon_Aligment; $Lon_Font_Size; $Lon_opacity; $Lon_parameters; $Lon_fontStyles; $Lon_x)
+C_REAL:C285($Num_interlining; $Num_stretch; $Num_x; $Num_y)
+C_TEXT:C284($Dom_svgObject; $Dom_svgReference; $kTxt_currentMethod; $Txt_Color; $Txt_Font_Name; $Txt_Name)
+C_TEXT:C284($Txt_style; $Txt_text)
 
 If (False:C215)
-	C_TEXT:C284(SVG_New_tspan ;$0)
-	C_TEXT:C284(SVG_New_tspan ;$1)
-	C_TEXT:C284(SVG_New_tspan ;$2)
-	C_REAL:C285(SVG_New_tspan ;$3)
-	C_REAL:C285(SVG_New_tspan ;$4)
-	C_TEXT:C284(SVG_New_tspan ;$5)
-	C_LONGINT:C283(SVG_New_tspan ;$6)
-	C_LONGINT:C283(SVG_New_tspan ;$7)
-	C_LONGINT:C283(SVG_New_tspan ;$8)
-	C_TEXT:C284(SVG_New_tspan ;$9)
+	C_TEXT:C284(SVG_New_tspan; $0)
+	C_TEXT:C284(SVG_New_tspan; $1)
+	C_TEXT:C284(SVG_New_tspan; $2)
+	C_REAL:C285(SVG_New_tspan; $3)
+	C_REAL:C285(SVG_New_tspan; $4)
+	C_TEXT:C284(SVG_New_tspan; $5)
+	C_LONGINT:C283(SVG_New_tspan; $6)
+	C_LONGINT:C283(SVG_New_tspan; $7)
+	C_LONGINT:C283(SVG_New_tspan; $8)
+	C_TEXT:C284(SVG_New_tspan; $9)
 End if 
 
-Compiler_SVG 
+Compiler_SVG
 
 $Lon_parameters:=Count parameters:C259
 $kTxt_currentMethod:="SVG_New_tspan"  //Nom methode courante
@@ -48,7 +48,7 @@ $kTxt_currentMethod:="SVG_New_tspan"  //Nom methode courante
 If ($Lon_parameters>=2)
 	
 	$Lon_Font_Size:=-1
-	$Lon_Styles:=-1
+	$Lon_fontStyles:=-1
 	$Lon_Aligment:=-1
 	$Num_interlining:=1
 	$Num_stretch:=1
@@ -59,17 +59,17 @@ If ($Lon_parameters>=2)
 	
 	If ($Lon_parameters>=3)
 		
-		$Num_x:=Choose:C955($3=-1;0;$3)  //X position
+		$Num_x:=Choose:C955($3=-1; 0; $3)  //X position
 		
 		If ($Lon_parameters>=4)
 			
-			$Num_y:=Choose:C955($4=-1;0;$4)  //Y position
+			$Num_y:=Choose:C955($4=-1; 0; $4)  //Y position
 			
 			If ($Lon_parameters>=5)
 				
-				If (Position:C15("{";$5)=1)  //Embedded style
+				If (Position:C15("{"; $5)=1)  //Embedded style
 					
-					$Txt_style:=Replace string:C233(Substring:C12($5;2);"}";"")
+					$Txt_style:=Replace string:C233(Substring:C12($5; 2); "}"; "")
 					
 				Else 
 					
@@ -77,11 +77,11 @@ If ($Lon_parameters>=2)
 					
 					If ($Lon_parameters>=6)
 						
-						$Lon_Font_Size:=Choose:C955($6=-1;0;$6)  //Default is 12 pt
+						$Lon_Font_Size:=Choose:C955($6=-1; 0; $6)  //Default is 12 pt
 						
 						If ($Lon_parameters>=7)
 							
-							$Lon_Styles:=$7  //Default is standard
+							$Lon_fontStyles:=$7  //Default is standard
 							
 							If ($Lon_parameters>=8)
 								
@@ -102,20 +102,20 @@ If ($Lon_parameters>=2)
 	
 	If (Length:C16($Txt_style)=0)
 		
-		$Lon_Font_Size:=Choose:C955($Lon_Font_Size=-1;12;$Lon_Font_Size)
+		$Lon_Font_Size:=Choose:C955($Lon_Font_Size=-1; 12; $Lon_Font_Size)
 		$Num_y:=$Num_y+$Lon_Font_Size
 		
 	End if 
 	
-	If (Asserted:C1132(xml_referenceValid ($Dom_svgObject);Get localized string:C991("error_badReference")))
+	If (Asserted:C1132(xml_referenceValid($Dom_svgObject); Get localized string:C991("error_badReference")))
 		
-		Component_errorHandler ("init";$kTxt_currentMethod)
+		Component_errorHandler("init"; $kTxt_currentMethod)
 		
-		DOM GET XML ELEMENT NAME:C730($Dom_svgObject;$Txt_Name)
+		DOM GET XML ELEMENT NAME:C730($Dom_svgObject; $Txt_Name)
 		
-		If (Position:C15($Txt_name+"|";"text|tspan|textArea|")>0)
+		If (Position:C15($Txt_name+"|"; "text|tspan|textArea|")>0)
 			
-			$Dom_svgReference:=DOM Create XML element:C865($Dom_svgObject;"tspan")
+			$Dom_svgReference:=DOM Create XML element:C865($Dom_svgObject; "tspan")
 			
 			If (OK=1)
 				
@@ -123,57 +123,57 @@ If ($Lon_parameters>=2)
 					 & (($Num_x#0)\
 					 | ($Num_y#0))
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"x";$Num_x;\
-						"y";$Num_y)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"x"; $Num_x; \
+						"y"; $Num_y)
 					
 				End if 
 				
 				If (Length:C16($Txt_style)>0)  //Embedded style
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"style";$Txt_style)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"style"; $Txt_style)
 					
 				Else 
 					
 					Case of   //font-family
 							
-							  //.....................................................
+							//.....................................................
 						: (OK=0)\
 							 | (Length:C16($Txt_Font_Name)=0)
 							
-							  //.....................................................
+							//.....................................................
 						Else 
 							
-							$Txt_Font_Name:=fontReplaceArial ($Txt_Font_Name)
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-family";$Txt_Font_Name)
+							$Txt_Font_Name:=fontReplaceArial($Txt_Font_Name)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"font-family"; $Txt_Font_Name)
 							
-							  //.....................................................
+							//.....................................................
 					End case 
 					
 					Case of   //fill (color)
 							
-							  //.....................................................
+							//.....................................................
 						: (OK=0)\
 							 | (Length:C16($Txt_Color)=0)
 							
-							  //.....................................................
+							//.....................................................
 						Else 
 							
-							$Lon_x:=Position:C15(":";$Txt_Color)
+							$Lon_x:=Position:C15(":"; $Txt_Color)
 							
 							If ($Lon_x>0)
 								
-								$Lon_opacity:=Num:C11(Substring:C12($Txt_Color;$Lon_x+1))
-								$Txt_Color:=Lowercase:C14(Substring:C12($Txt_Color;1;$Lon_x-1))
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"fill";$Txt_Color)
+								$Lon_opacity:=Num:C11(Substring:C12($Txt_Color; $Lon_x+1))
+								$Txt_Color:=Lowercase:C14(Substring:C12($Txt_Color; 1; $Lon_x-1))
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"fill"; $Txt_Color)
 								
 								If (OK=1)
 									
-									DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-										"fill-opacity";$Lon_opacity/100)
+									DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+										"fill-opacity"; $Lon_opacity/100)
 									
 								End if 
 								
@@ -181,148 +181,141 @@ If ($Lon_parameters>=2)
 								
 								If ($Txt_Color="url(@")
 									
-									DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-										"fill";$Txt_Color)
+									DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+										"fill"; $Txt_Color)
 									
 								Else 
 									
-									DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-										"fill";Lowercase:C14($Txt_Color))
+									DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+										"fill"; Lowercase:C14($Txt_Color))
 									
 								End if 
 							End if 
 							
-							  //.....................................................
+							//.....................................................
 					End case 
 					
 					Case of   //text-decoration, font-style & font-weight
 							
-							  //.....................................................
+							//.....................................................
 						: (OK=0)\
-							 | ($Lon_Styles<0)
+							 | ($Lon_fontStyles<0)
 							
-							  //.....................................................
-						: ($Lon_Styles=0)
+							//.....................................................
+						: ($Lon_fontStyles=0)
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-decoration";"none")
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"text-decoration"; "none")
 							
 							If (OK=1)
 								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"font-style";"normal")
+								DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+									"font-style"; "normal")
 								
 								If (OK=1)
 									
-									DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-										"font-weight";"normal")
+									DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+										"font-weight"; "normal")
 									
 								End if 
 							End if 
 							
-							  //.....................................................
+							//.....................................................
 						Else 
 							
-							If ($Lon_Styles>=8)  //line-through
-								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"text-decoration";"line-through")
-								$Lon_Styles:=$Lon_Styles-8
-								
+							Case of 
+								: ($Lon_fontStyles ?? 2) & ($Lon_fontStyles ?? 3)
+									DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+										"text-decoration"; "underline line-through")
+									
+								: ($Lon_fontStyles ?? 2)
+									DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+										"text-decoration"; "underline")
+									
+								: ($Lon_fontStyles ?? 3)
+									DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+										"text-decoration"; "line-through")
+							End case 
+							
+							If ($Lon_fontStyles ?? 1)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+									"font-style"; "italic")
 							End if 
 							
-							If ($Lon_Styles>=4)  //underline
-								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"text-decoration";"underline")
-								$Lon_Styles:=$Lon_Styles-4
-								
+							If ($Lon_fontStyles ?? 0)
+								DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+									"font-weight"; "bold")
 							End if 
 							
-							If ($Lon_Styles>=2)  //italic
-								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"font-style";"italic")
-								$Lon_Styles:=$Lon_Styles-2
-								
-							End if 
-							
-							If ($Lon_Styles=1)  //bold
-								
-								DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-									"font-weight";"bold")
-								
-							End if 
-							
-							  //.....................................................
+							//.....................................................
 					End case 
 					
 					Case of   //font-size
 							
-							  //.....................................................
+							//.....................................................
 						: (OK=0)\
 							 | ($Lon_Font_Size<=0)
 							
-							  //.....................................................
+							//.....................................................
 						Else 
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-size";$Lon_Font_Size)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"font-size"; $Lon_Font_Size)
 							
-							  //.....................................................
+							//.....................................................
 					End case 
 					
 					Case of   //text-anchor
 							
-							  //.....................................................
+							//.....................................................
 						: (OK=0)\
 							 | ($Lon_Aligment<0)
 							
-							  //.....................................................
+							//.....................................................
 						: ($Lon_Aligment=Align center:K42:3)
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-anchor";"middle")
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"text-anchor"; "middle")
 							
-							  //.....................................................
+							//.....................................................
 						: ($Lon_Aligment=Align right:K42:4)
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-anchor";"end")
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"text-anchor"; "end")
 							
-							  //.....................................................
+							//.....................................................
 						: ($Lon_Aligment=Align left:K42:2)
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-anchor";"start")
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"text-anchor"; "start")
 							
-							  //.....................................................
+							//.....................................................
 						Else 
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"text-anchor";"inherit")
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"text-anchor"; "inherit")
 							
-							  //.....................................................
+							//.....................................................
 					End case 
 				End if 
 				
 				If (OK=1)
 					
-					  // 25-1-2017 - Encode special characters
-					  // #ACI0097138
-					  //$Txt_text:=xml_Escape_characters ($Txt_text)
+					// 25-1-2017 - Encode special characters
+					// #ACI0097138
+					//$Txt_text:=xml_Escape_characters ($Txt_text)
 					
-					DOM SET XML ELEMENT VALUE:C868($Dom_svgReference;$Txt_text)
+					DOM SET XML ELEMENT VALUE:C868($Dom_svgReference; $Txt_text)
 					
 				End if 
 				
 				If (OK=1)
 					
-					  //Set the id
+					//Set the id
 					If (Storage:C1525.svg.options ?? 1)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"id";$Dom_svgReference)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"id"; $Dom_svgReference)
 						
 					End if 
 					
@@ -336,20 +329,20 @@ If ($Lon_parameters>=2)
 			
 		Else 
 			
-			ASSERT:C1129(Component_putError (8854))  //Impossible to apply this Command for this Node
+			ASSERT:C1129(Component_putError(8854))  //Impossible to apply this Command for this Node
 			
 		End if 
 		
-		ASSERT:C1129(Component_errorHandler ("deinit"))
+		ASSERT:C1129(Component_errorHandler("deinit"))
 		
 	Else 
 		
-		ASSERT:C1129(Component_putError (8852;$kTxt_currentMethod))  //The reference is not a svg object
+		ASSERT:C1129(Component_putError(8852; $kTxt_currentMethod))  //The reference is not a svg object
 		
 	End if 
 	
 Else 
 	
-	ASSERT:C1129(Component_putError (8850;$kTxt_currentMethod))  //Parameters Missing
+	ASSERT:C1129(Component_putError(8850; $kTxt_currentMethod))  //Parameters Missing
 	
 End if 

--- a/Project/Sources/Methods/SVG_New_vertical_text.4dm
+++ b/Project/Sources/Methods/SVG_New_vertical_text.4dm
@@ -1,11 +1,11 @@
 //%attributes = {"invisible":true,"shared":true,"preemptive":"capable"}
-  // ----------------------------------------------------
-  // Method : SVG_New_vertical_text
-  // Created 26/08/08 by Vincent de Lachaux
-  // ----------------------------------------------------
-  // Description
-  //
-  // ----------------------------------------------------
+// ----------------------------------------------------
+// Method : SVG_New_vertical_text
+// Created 26/08/08 by Vincent de Lachaux
+// ----------------------------------------------------
+// Description
+//
+// ----------------------------------------------------
 C_TEXT:C284($0)
 C_TEXT:C284($1)
 C_TEXT:C284($2)
@@ -18,27 +18,27 @@ C_LONGINT:C283($8)
 C_TEXT:C284($9)
 C_REAL:C285($10)
 
-C_LONGINT:C283($Lon_Aligment;$Lon_Count;$Lon_Font_Size;$Lon_i;$Lon_opacity;$Lon_parameters)
-C_LONGINT:C283($Lon_Styles;$Lon_x)
-C_REAL:C285($Num_rotation;$Num_x;$Num_y)
-C_TEXT:C284($Dom_svgObject;$Dom_svgReference;$kTxt_currentMethod;$Txt_character;$Txt_Color;$Txt_Font_Name)
-C_TEXT:C284($Txt_Span;$Txt_text)
+C_LONGINT:C283($Lon_Aligment; $Lon_Count; $Lon_Font_Size; $Lon_i; $Lon_opacity; $Lon_parameters)
+C_LONGINT:C283($Lon_fontStyles; $Lon_x)
+C_REAL:C285($Num_rotation; $Num_x; $Num_y)
+C_TEXT:C284($Dom_svgObject; $Dom_svgReference; $kTxt_currentMethod; $Txt_character; $Txt_Color; $Txt_Font_Name)
+C_TEXT:C284($Txt_Span; $Txt_text)
 
 If (False:C215)
-	C_TEXT:C284(SVG_New_vertical_text ;$0)
-	C_TEXT:C284(SVG_New_vertical_text ;$1)
-	C_TEXT:C284(SVG_New_vertical_text ;$2)
-	C_REAL:C285(SVG_New_vertical_text ;$3)
-	C_REAL:C285(SVG_New_vertical_text ;$4)
-	C_TEXT:C284(SVG_New_vertical_text ;$5)
-	C_LONGINT:C283(SVG_New_vertical_text ;$6)
-	C_LONGINT:C283(SVG_New_vertical_text ;$7)
-	C_LONGINT:C283(SVG_New_vertical_text ;$8)
-	C_TEXT:C284(SVG_New_vertical_text ;$9)
-	C_REAL:C285(SVG_New_vertical_text ;$10)
+	C_TEXT:C284(SVG_New_vertical_text; $0)
+	C_TEXT:C284(SVG_New_vertical_text; $1)
+	C_TEXT:C284(SVG_New_vertical_text; $2)
+	C_REAL:C285(SVG_New_vertical_text; $3)
+	C_REAL:C285(SVG_New_vertical_text; $4)
+	C_TEXT:C284(SVG_New_vertical_text; $5)
+	C_LONGINT:C283(SVG_New_vertical_text; $6)
+	C_LONGINT:C283(SVG_New_vertical_text; $7)
+	C_LONGINT:C283(SVG_New_vertical_text; $8)
+	C_TEXT:C284(SVG_New_vertical_text; $9)
+	C_REAL:C285(SVG_New_vertical_text; $10)
 End if 
 
-Compiler_SVG 
+Compiler_SVG
 
 $Lon_parameters:=Count parameters:C259
 $kTxt_currentMethod:="SVG_New_vertical_text"  //Nom methode courante
@@ -49,7 +49,7 @@ If ($Lon_parameters>=2)
 	$Txt_text:=$2  //String to write
 	
 	$Lon_Font_Size:=-1
-	$Lon_Styles:=-1
+	$Lon_fontStyles:=-1
 	
 	If ($Lon_parameters>=3)
 		
@@ -69,7 +69,7 @@ If ($Lon_parameters>=2)
 					
 					If ($Lon_parameters>=7)
 						
-						$Lon_Styles:=$7  //Default is standard
+						$Lon_fontStyles:=$7  //Default is standard
 						
 						If ($Lon_parameters>=8)
 							
@@ -98,65 +98,65 @@ If ($Lon_parameters>=2)
 		
 	End if 
 	
-	If (Asserted:C1132(xml_referenceValid ($Dom_svgObject);Get localized string:C991("error_badReference")))
+	If (Asserted:C1132(xml_referenceValid($Dom_svgObject); Get localized string:C991("error_badReference")))
 		
-		Component_errorHandler ("init";$kTxt_currentMethod)
+		Component_errorHandler("init"; $kTxt_currentMethod)
 		
-		$Dom_svgReference:=DOM Create XML element:C865($Dom_svgObject;"text")
+		$Dom_svgReference:=DOM Create XML element:C865($Dom_svgObject; "text")
 		
 		If (OK=1)
 			
 			If ($Num_x#0)\
 				 | ($Num_y#0)
 				
-				DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-					"x";$Num_x;\
-					"y";$Num_y)
+				DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+					"x"; $Num_x; \
+					"y"; $Num_y)
 				
 			End if 
 			
 			Case of   //font-family
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)
 					
-					  //.....................................................
+					//.....................................................
 				: (Length:C16($Txt_Font_Name)=0)
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					$Txt_Font_Name:=fontReplaceArial ($Txt_Font_Name)
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"font-family";$Txt_Font_Name)
+					$Txt_Font_Name:=fontReplaceArial($Txt_Font_Name)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"font-family"; $Txt_Font_Name)
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			Case of 
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)
 					
-					  //.....................................................
+					//.....................................................
 				: (Length:C16($Txt_Color)=0)
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					$Lon_x:=Position:C15(":";$Txt_Color)
+					$Lon_x:=Position:C15(":"; $Txt_Color)
 					
 					If ($Lon_x>0)
 						
-						$Lon_opacity:=Num:C11(Substring:C12($Txt_Color;$Lon_x+1))
-						$Txt_Color:=Lowercase:C14(Substring:C12($Txt_Color;1;$Lon_x-1))
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"fill";$Txt_Color)
+						$Lon_opacity:=Num:C11(Substring:C12($Txt_Color; $Lon_x+1))
+						$Txt_Color:=Lowercase:C14(Substring:C12($Txt_Color; 1; $Lon_x-1))
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"fill"; $Txt_Color)
 						
 						If (OK=1)
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"fill-opacity";$Lon_opacity/100)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"fill-opacity"; $Lon_opacity/100)
 							
 						End if 
 						
@@ -164,164 +164,157 @@ If ($Lon_parameters>=2)
 						
 						If ($Txt_Color="url(@")
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"fill";$Txt_Color)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"fill"; $Txt_Color)
 							
 						Else 
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"fill";Lowercase:C14($Txt_Color))
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"fill"; Lowercase:C14($Txt_Color))
 							
 						End if 
 					End if 
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			Case of 
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)
 					
-					  //.....................................................
-				: ($Lon_Styles<0)
+					//.....................................................
+				: ($Lon_fontStyles<0)
 					
-					  //.....................................................
-				: ($Lon_Styles=0)
+					//.....................................................
+				: ($Lon_fontStyles=0)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"text-decoration";"none")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"text-decoration"; "none")
 					
 					If (OK=1)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"font-style";"normal")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+							"font-style"; "normal")
 						
 						If (OK=1)
 							
-							DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-								"font-weight";"normal")
+							DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+								"font-weight"; "normal")
 							
 						End if 
 					End if 
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					If ($Lon_Styles>=8)  //line-through
-						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-decoration";"line-through")
-						$Lon_Styles:=$Lon_Styles-8
-						
+					Case of 
+						: ($Lon_fontStyles ?? 2) & ($Lon_fontStyles ?? 3)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+								"text-decoration"; "underline line-through")
+							
+						: ($Lon_fontStyles ?? 2)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+								"text-decoration"; "underline")
+							
+						: ($Lon_fontStyles ?? 3)
+							DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+								"text-decoration"; "line-through")
+					End case 
+					
+					If ($Lon_fontStyles ?? 1)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+							"font-style"; "italic")
 					End if 
 					
-					If ($Lon_Styles>=4)  //underline
-						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"text-decoration";"underline")
-						$Lon_Styles:=$Lon_Styles-4
-						
+					If ($Lon_fontStyles ?? 0)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+							"font-weight"; "bold")
 					End if 
 					
-					If ($Lon_Styles>=2)  //italic
-						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"font-style";"italic")
-						$Lon_Styles:=$Lon_Styles-2
-						
-					End if 
-					
-					If ($Lon_Styles=1)  //bold
-						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-							"font-weight";"bold")
-						
-					End if 
-					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			Case of 
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)
 					
-					  //.....................................................
+					//.....................................................
 				: ($Lon_Font_Size<0)
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"font-size";$Lon_Font_Size)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"font-size"; $Lon_Font_Size)
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			Case of 
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)
 					
-					  //.....................................................
+					//.....................................................
 				: ($Lon_Aligment=0)
 					
-					  //.....................................................
+					//.....................................................
 				: ($Lon_Aligment=Align center:K42:3)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"text-anchor";"middle")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"text-anchor"; "middle")
 					
-					  //.....................................................
+					//.....................................................
 				: ($Lon_Aligment=Align right:K42:4)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"text-anchor";"end")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"text-anchor"; "end")
 					
-					  //.....................................................
+					//.....................................................
 				: ($Lon_Aligment=Align left:K42:2)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"text-anchor";"start")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"text-anchor"; "start")
 					
-					  //.....................................................
+					//.....................................................
 				: ($Lon_Aligment=Align default:K42:1)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"text-anchor";"start")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"text-anchor"; "start")
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"text-anchor";"inherit")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"text-anchor"; "inherit")
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			Case of 
 					
-					  //.....................................................
+					//.....................................................
 				: (OK=0)
 					
-					  //.....................................................
+					//.....................................................
 				: ($Num_rotation=0)
 					
-					  //.....................................................
+					//.....................................................
 				Else 
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"transform";"rotate("+String:C10($Num_rotation)+")")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"transform"; "rotate("+String:C10($Num_rotation)+")")
 					
-					  //.....................................................
+					//.....................................................
 			End case 
 			
 			If (OK=1)
 				
 				$Lon_Count:=0
 				
-				For ($Lon_i;1;Length:C16($Txt_text);1)
+				For ($Lon_i; 1; Length:C16($Txt_text); 1)
 					
 					$Txt_character:=$Txt_text[[$Lon_i]]
 					
@@ -333,25 +326,25 @@ If ($Lon_parameters>=2)
 					Else 
 						
 						$Lon_Count:=$Lon_Count+1
-						$Txt_Span:=DOM Create XML element:C865($Dom_svgReference;"tspan";\
-							"x";$Num_x)
+						$Txt_Span:=DOM Create XML element:C865($Dom_svgReference; "tspan"; \
+							"x"; $Num_x)
 						
 						If (OK=1)
 							
-							DOM SET XML ATTRIBUTE:C866($Txt_Span;\
-								"y";$Num_y+($Lon_Font_Size*$Lon_Count*7/8))
+							DOM SET XML ATTRIBUTE:C866($Txt_Span; \
+								"y"; $Num_y+($Lon_Font_Size*$Lon_Count*7/8))
 							
 							If (OK=1)\
 								 & ($Num_rotation#0)
 								
-								DOM SET XML ATTRIBUTE:C866($Txt_Span;\
-									"transform";"rotate("+String:C10($Num_rotation)+")")
+								DOM SET XML ATTRIBUTE:C866($Txt_Span; \
+									"transform"; "rotate("+String:C10($Num_rotation)+")")
 								
 							End if 
 							
 							If (OK=1)
 								
-								DOM SET XML ELEMENT VALUE:C868($Txt_Span;$Txt_character)
+								DOM SET XML ELEMENT VALUE:C868($Txt_Span; $Txt_character)
 								
 							End if 
 						End if 
@@ -361,15 +354,15 @@ If ($Lon_parameters>=2)
 			
 			If (OK=1)
 				
-				  //Set the id
-				  //{
+				//Set the id
+				//{
 				If (Storage:C1525.svg.options ?? 1)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgReference;\
-						"id";$Dom_svgReference)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgReference; \
+						"id"; $Dom_svgReference)
 					
 				End if 
-				  //}
+				//}
 				
 				If (OK=1)
 					
@@ -379,16 +372,16 @@ If ($Lon_parameters>=2)
 			End if 
 		End if 
 		
-		ASSERT:C1129(Component_errorHandler ("deinit"))
+		ASSERT:C1129(Component_errorHandler("deinit"))
 		
 	Else 
 		
-		ASSERT:C1129(Component_putError (8852;$kTxt_currentMethod))  //The reference is not a svg object
+		ASSERT:C1129(Component_putError(8852; $kTxt_currentMethod))  //The reference is not a svg object
 		
 	End if 
 	
 Else 
 	
-	ASSERT:C1129(Component_putError (8850;$kTxt_currentMethod))  //Parameters Missing
+	ASSERT:C1129(Component_putError(8850; $kTxt_currentMethod))  //Parameters Missing
 	
 End if 

--- a/Project/Sources/Methods/SVG_SET_FONT_STYLE.4dm
+++ b/Project/Sources/Methods/SVG_SET_FONT_STYLE.4dm
@@ -1,23 +1,23 @@
 //%attributes = {"invisible":true,"shared":true,"preemptive":"capable"}
-  // ----------------------------------------------------
-  // Method : SVG_SET_FONT_STYLE
-  // Created 10/07/08 by Vincent de Lachaux
-  // ----------------------------------------------------
-  // Description
-  //
-  // ----------------------------------------------------
+// ----------------------------------------------------
+// Method : SVG_SET_FONT_STYLE
+// Created 10/07/08 by Vincent de Lachaux
+// ----------------------------------------------------
+// Description
+//
+// ----------------------------------------------------
 C_TEXT:C284($1)
 C_LONGINT:C283($2)
 
-C_LONGINT:C283($Lon_fontStyle;$Lon_parameters)
-C_TEXT:C284($Dom_svgObject;$kTxt_currentMethod;$Txt_Name)
+C_LONGINT:C283($Lon_fontStyles; $Lon_parameters)
+C_TEXT:C284($Dom_svgObject; $kTxt_currentMethod; $Txt_Name)
 
 If (False:C215)
-	C_TEXT:C284(SVG_SET_FONT_STYLE ;$1)
-	C_LONGINT:C283(SVG_SET_FONT_STYLE ;$2)
+	C_TEXT:C284(SVG_SET_FONT_STYLE; $1)
+	C_LONGINT:C283(SVG_SET_FONT_STYLE; $2)
 End if 
 
-Compiler_SVG 
+Compiler_SVG
 
 $Lon_parameters:=Count parameters:C259
 $kTxt_currentMethod:="SVG_SET_FONT_STYLE"  //Nom methode courante
@@ -25,91 +25,85 @@ $kTxt_currentMethod:="SVG_SET_FONT_STYLE"  //Nom methode courante
 If ($Lon_parameters>=2)
 	
 	$Dom_svgObject:=$1
-	$Lon_fontStyle:=$2
+	$Lon_fontStyles:=$2
 	
-	If (Asserted:C1132(xml_referenceValid ($Dom_svgObject);Get localized string:C991("error_badReference")))
+	If (Asserted:C1132(xml_referenceValid($Dom_svgObject); Get localized string:C991("error_badReference")))
 		
-		Component_errorHandler ("init";$kTxt_currentMethod)
+		Component_errorHandler("init"; $kTxt_currentMethod)
 		
-		DOM GET XML ELEMENT NAME:C730($Dom_svgObject;$Txt_Name)
+		DOM GET XML ELEMENT NAME:C730($Dom_svgObject; $Txt_Name)
 		
-		ARRAY TEXT:C222($tTxt_objects;0x0000)
-		COLLECTION TO ARRAY:C1562(Storage:C1525.svg["text content element"];$tTxt_objects)
+		ARRAY TEXT:C222($tTxt_objects; 0x0000)
+		COLLECTION TO ARRAY:C1562(Storage:C1525.svg["text content element"]; $tTxt_objects)
 		
 		
-		If (Find in array:C230($tTxt_objects;$Txt_Name)>0)
+		If (Find in array:C230($tTxt_objects; $Txt_Name)>0)
 			
-			If ($Lon_fontStyle=0)
+			If ($Lon_fontStyles=0)
 				
-				DOM SET XML ATTRIBUTE:C866($Dom_svgObject;\
-					"text-decoration";"none")
+				DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+					"text-decoration"; "none")
 				
 				If (OK=1)
 					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgObject;\
-						"font-style";"normal")
+					DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+						"font-style"; "normal")
 					
 					If (OK=1)
 						
-						DOM SET XML ATTRIBUTE:C866($Dom_svgObject;\
-							"font-weight";"normal")
+						DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+							"font-weight"; "normal")
 						
 					End if 
 				End if 
 				
 			Else 
 				
-				If ($Lon_fontStyle>=8)  //line-through
-					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgObject;\
-						"text-decoration";"line-through")
-					$Lon_fontStyle:=$Lon_fontStyle-8
-					
+				Case of 
+					: ($Lon_fontStyles ?? 2) & ($Lon_fontStyles ?? 3)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+							"text-decoration"; "underline line-through")
+						
+					: ($Lon_fontStyles ?? 2)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+							"text-decoration"; "underline")
+						
+					: ($Lon_fontStyles ?? 3)
+						DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+							"text-decoration"; "line-through")
+				End case 
+				
+				If ($Lon_fontStyles ?? 1)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+						"font-style"; "italic")
 				End if 
 				
-				If ($Lon_fontStyle>=4)  //underline
-					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgObject;\
-						"text-decoration";"underline")
-					$Lon_fontStyle:=$Lon_fontStyle-4
-					
+				If ($Lon_fontStyles ?? 0)
+					DOM SET XML ATTRIBUTE:C866($Dom_svgObject; \
+						"font-weight"; "bold")
 				End if 
 				
-				If ($Lon_fontStyle>=2)  //italic
-					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgObject;\
-						"font-style";"italic")
-					$Lon_fontStyle:=$Lon_fontStyle-2
-					
-				End if 
-				
-				If ($Lon_fontStyle=1)  //bold
-					
-					DOM SET XML ATTRIBUTE:C866($Dom_svgObject;\
-						"font-weight";"bold")
-					
-				End if 
 			End if 
 			
-			ASSERT:C1129(Component_errorHandler ("deinit"))
+			ASSERT:C1129(Component_errorHandler("deinit"))
 			
 		Else 
 			
-			ASSERT:C1129(Component_putError (8854))  //Impossible to apply this Command for this Node
+			ASSERT:C1129(Component_putError(8854))  //Impossible to apply this Command for this Node
 			
 		End if 
 		
-		  //#ACI0091143
+		//#ACI0091143
 		CLEAR VARIABLE:C89($tTxt_objects)
 		
 	Else 
 		
-		ASSERT:C1129(Component_putError (8852;$kTxt_currentMethod))  //The reference is not a svg object
+		ASSERT:C1129(Component_putError(8852; $kTxt_currentMethod))  //The reference is not a svg object
 		
 	End if 
 	
 Else 
 	
-	ASSERT:C1129(Component_putError (8850;$kTxt_currentMethod))  //Parameters Missing
+	ASSERT:C1129(Component_putError(8850; $kTxt_currentMethod))  //Parameters Missing
 	
 End if 


### PR DESCRIPTION
Refactor the font styles in order to be able to have `underline` and `strikethrough` together.

Use bit test to test each property
Harmonize the different variable names in different function.

I didn't create one method to do the work because it was done this way. But it would be better to have only one place where this code is done.